### PR TITLE
fix building on distros that already use xbps

### DIFF
--- a/autobuild-ng.sh
+++ b/autobuild-ng.sh
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
 if [ -z "$1" ]; then
-	export ARCH=x86_64
-	XBPS_ARCH=x86_64-musl
+	export ARCH=$(uname -m)
+	XBPS_ARCH=$ARCH-musl
 else
 	export ARCH=$1
 	XBPS_ARCH=$1-musl
@@ -39,9 +39,11 @@ printf 'root:x:0:root\n' > ./sysroot/etc/group
 printf 'root:x:0:0:,,,:/root:/bin/sh' > ./sysroot/etc/passwd
 
 mkdir -p ./sysroot/usr/bin
-if command -V qemu-$1-static
-then
-	cp $(command -V qemu-$1-static | rev | cut -d' ' -f1 | rev) ./sysroot/usr/bin/
+if [ ! -z "$1" ]; then
+	if command -V qemu-$1-static
+	then
+		cp $(command -V qemu-$1-static | rev | cut -d' ' -f1 | rev) ./sysroot/usr/bin/
+	fi
 fi
 
 # setup chroot

--- a/autobuild-ng.sh
+++ b/autobuild-ng.sh
@@ -183,7 +183,7 @@ zstd --ultra -22 pkgs.tar
 cd $BUILD_BASE
 
 efi() {
-	sudo $IGLU add $IGLUNIX_BASE/$1/out/*-*.xbps -r $BUILD_BASE/initrd -y -a $XBPS_ARCH
+	sudo $IGLU add -y -a $XBPS_ARCH -r $BUILD_BASE/initrd $IGLUNIX_BASE/$1/out/*-*.xbps
 }
 
 echo === Assembling initrd ===


### PR DESCRIPTION
Please note that this PR depends on the following: https://github.com/iglunix/iglupkg/pull/2

Every time the iglu.sh script is invoked to install packages, we now pass the desired architecture to the script.
This circumvents running into an mismatched arch error if your distro already uses xbps.

Example: host xbps is x86_64, but packages are built for x86_64-musl. This causes xbps-rindex to fail due to a architecture mismatch.